### PR TITLE
remove the shift key effect -> toggling on/off the spatial pointer

### DIFF
--- a/content_scripts/multiclientUI.js
+++ b/content_scripts/multiclientUI.js
@@ -58,7 +58,7 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
     window.wireMat = wireMat;
 
     function initService() {
-        if (!realityEditor.device.desktopAdapter || !realityEditor.device.KeyboardListener || !realityEditor.gui.getMenuBar) {
+        if (!realityEditor.device.desktopAdapter || !realityEditor.gui.getMenuBar) {
             setTimeout(initService, 100);
             return;
         }
@@ -72,26 +72,6 @@ import * as THREE from '../../thirdPartyCode/three/three.module.js';
         });
 
         update();
-
-        let keyboard = new realityEditor.device.KeyboardListener();
-        keyboard.onKeyDown(function(code) {
-            if (realityEditor.device.keyboardEvents.isKeyboardActive()) { return; } // ignore if a tool is using the keyboard
-
-            // while shift is down, turn on the laser beam
-            if (code === keyboard.keyCodes.SHIFT) {
-                let touchPosition = realityEditor.gui.ar.positioning.getMostRecentTouchPosition();
-                realityEditor.avatar.setBeamOn(touchPosition.x, touchPosition.y);
-            }
-        });
-        keyboard.onKeyUp(function(code) {
-            if (realityEditor.device.keyboardEvents.isKeyboardActive()) { return; } // ignore if a tool is using the keyboard
-
-            // when shift is released, turn off the laser beam
-            if (code === keyboard.keyCodes.SHIFT) {
-                let touchPosition = realityEditor.gui.ar.positioning.getMostRecentTouchPosition();
-                realityEditor.avatar.setBeamOff(touchPosition.x, touchPosition.y);
-            }
-        });
 
         realityEditor.gui.getMenuBar().addCallbackToItem(realityEditor.gui.ITEM.ViewCones, (toggled) => {
             showViewCones = toggled;


### PR DESCRIPTION
...so it doesn't conflict with other keyboard shortcuts.

Alternatively I could switch it to an obscure keyboard key, but I feel like no one uses it this way anyways except for me in some niche demo scenarios when I need to be drawing and pointing intermittently. 