### PR TITLE
Improved mobile scan preview

### DIFF
--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -443,7 +443,7 @@ import Splatting from '../../src/splatting/Splatting.js';
                         this.mouseInput.unprocessedDX += xOffset;
                         this.mouseInput.unprocessedDY += yOffset;
                     } else if (this.touchControlMode === 'zoom') {
-                        const biggerDirection = Math.abs(yOffset) > Math.abs(xOffset) ? yOffset : xOffset;
+                        const biggerDirection = Math.abs(yOffset) > Math.abs(xOffset) ? yOffset : -xOffset;
                         this.mouseInput.unprocessedScroll += (biggerDirection * 2);
                     }
                 }

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -805,6 +805,7 @@ import { CameraPositionMemoryBar } from './CameraPositionMemoryBar.js';
 
             if (touchControlButtons) {
                 touchControlButtons.activate();
+                // onTransitionPercent can override this with 'rotate' if we slide all the way to the right
                 touchControlButtons.selectMode('pointer'); // select pointer mode by default
             }
         });
@@ -819,6 +820,18 @@ import { CameraPositionMemoryBar } from './CameraPositionMemoryBar.js';
             if (touchControlButtons) {
                 touchControlButtons.deactivate();
                 touchControlButtons.selectMode(null); // deselect all modes and propagate state to virtual camera
+            }
+        });
+
+        realityEditor.device.modeTransition.onTransitionPercent((percent) => {
+            if (touchControlButtons) {
+                if (percent >= 1 && touchControlButtons.container.classList.contains('hidden-controls-transition')) {
+                    touchControlButtons.container.classList.remove('hidden-controls-transition');
+                    touchControlButtons.selectMode(touchControlButtons.MODES.rotate);
+                } else if (percent < 1 && !touchControlButtons.container.classList.contains('hidden-controls-transition')) {
+                    touchControlButtons.container.classList.add('hidden-controls-transition');
+                    touchControlButtons.selectMode(touchControlButtons.MODES.pointer);
+                }
             }
         });
     }

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -6,6 +6,8 @@
 * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
+/* global overlayDiv, overlayDiv2 */
+
 createNameSpace('realityEditor.device.desktopCamera');
 
 import { Vector3 } from '../../thirdPartyCode/three/three.module.js';
@@ -828,9 +830,26 @@ import { CameraPositionMemoryBar } from './CameraPositionMemoryBar.js';
                 if (percent >= 1 && touchControlButtons.container.classList.contains('hidden-controls-transition')) {
                     touchControlButtons.container.classList.remove('hidden-controls-transition');
                     touchControlButtons.selectMode(touchControlButtons.MODES.rotate);
+
+                    // just in case, turn off the pointer beam since we're changing the mode
+                    realityEditor.avatar.setBeamOff();
+                    updatePointerOccupiedByCamera();
+                    // hide and reset the overlay divs, since touch camera controls interrupt their normal behavior
+                    [overlayDiv, overlayDiv2].forEach((overlay) => {
+                        overlay.style.display = 'none';
+                    });
+
                 } else if (percent < 1 && !touchControlButtons.container.classList.contains('hidden-controls-transition')) {
                     touchControlButtons.container.classList.add('hidden-controls-transition');
                     touchControlButtons.selectMode(touchControlButtons.MODES.pointer);
+
+                    // just in case, hide the interaction cursor (shown during zoom, rotate, pan)
+                    cameraTargetIcon.visible = false;
+                    updateInteractionCursor(cameraTargetIcon.visible, 'addons/vuforia-spatial-remote-operator-addon/cameraRotate.svg');
+                    knownInteractionStates.pan = false;
+                    knownInteractionStates.rotate = false;
+                    knownInteractionStates.zoom = false;
+                    updatePointerOccupiedByCamera();
                 }
             }
         });

--- a/content_styles/remoteOperator.css
+++ b/content_styles/remoteOperator.css
@@ -275,6 +275,10 @@ body > * {
     transform: translateZ(1000px);
 }
 
+.hidden-controls-transition {
+    display: none;
+}
+
 .touchControlButtonContainer {
     width: 44px;
     height: 44px;


### PR DESCRIPTION
Bonus feature for remote operator: centers the camera to look at the center of the scan when the scene loads, instead of the arbitrary (0,0,0) position.

Features for mobile Preview Scan:
- orbiting in the scan preview always orbits the scan around its centroid, rather than where you tap (easier to navigate)
- the touch control buttons (zoom, rotate, pan) only show up when you're in the slider's "Orbit" state (all the way to the right). makes it clearer what each mode does.
- clears visual state when you transition from AR to Look to Orbit mode, so that the avatar pointer beam and other 2d cursor UI doesn't get stuck on the screen

Goes with https://github.com/dataTimeSpace/pop-up-onboarding-addon/pull/49