### PR TITLE
Adjustments for resizable viewport and new raycast method

### DIFF
--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -273,12 +273,14 @@ import { getRaycastPoint } from '../../src/gui/ar/raycast.js';
 
             let scrollTimeout = null;
             window.addEventListener('wheel', function (event) {
-                let viewportRect = realityEditor.device.layout.getCachedViewportRect();
-                if (event.pageX < viewportRect.left ||
-                    event.pageY < viewportRect.top ||
-                    event.pageX > viewportRect.left + viewportRect.width ||
-                    event.pageY > viewportRect.top + viewportRect.height) {
-                    return; // skip if the event occurs outside the viewport
+                if (typeof realityEditor.device.layout.getViewportRect !== 'undefined') {
+                    let viewportRect = realityEditor.device.layout.getViewportRect();
+                    if (event.pageX < viewportRect.left ||
+                        event.pageY < viewportRect.top ||
+                        event.pageX > viewportRect.left + viewportRect.width ||
+                        event.pageY > viewportRect.top + viewportRect.height) {
+                        return; // skip if the event occurs outside the viewport
+                    }
                 }
 
                 // restrict deltaY between [-100, 100], to prevent mouse wheel deltaY so large that camera cannot focus on focus point when zooming in
@@ -686,7 +688,11 @@ import { getRaycastPoint } from '../../src/gui/ar/raycast.js';
         reset() {
             this.stopFollowing();
             this.position = [this.initialPosition[0], this.initialPosition[1], this.initialPosition[2]];
-            this.targetPosition = [0, 0, 0];
+            if (this.navmeshCentroid) {
+                this.targetPosition = [this.navmeshCentroid.x, this.navmeshCentroid.y, this.navmeshCentroid.z];
+            } else {
+                this.targetPosition = [0, 0, 0];
+            }
             this.mouseInput.lastWorldPos = [0, 0, 0];
             this.mouseInput.startOrbitPos = [0, 0, 0];
             this.focusTargetCube.position.copy(new THREE.Vector3().fromArray(this.mouseInput.lastWorldPos));

--- a/content_scripts/VirtualCamera.js
+++ b/content_scripts/VirtualCamera.js
@@ -7,12 +7,14 @@ createNameSpace('realityEditor.device');
 import * as THREE from '../../thirdPartyCode/three/three.module.js';
 import Splatting from '../../src/splatting/Splatting.js';
 
-let getRaycastPoint; // import { getRaycastPoint } from '../../src/gui/ar/raycast.js'; <-- use this when we've fully migrated
+let getRaycastPoint; // import { getRaycastPoint } from '../../src/gui/ar/raycastHelper.js'; <-- use this when we've fully migrated
+let SPACES;
 try {
-    let raycastModule = await import('../../src/gui/ar/raycast.js');
+    let raycastModule = await import('../../src/gui/ar/raycastHelper.js');
     getRaycastPoint = raycastModule.getRaycastPoint;
+    SPACES = raycastModule.SPACES;
 } catch (_err) {
-    console.warn('[VirtualCamera.js] raycast.js not found, skipping import.');
+    console.warn('[VirtualCamera.js] raycastHelper.js not found, skipping import.');
 }
 
 (function (exports) {
@@ -253,11 +255,10 @@ try {
                     // this automatically accounts for viewport vs page coordinates
                     worldIntersectPoint = await getRaycastPoint({
                         coords: { page: { x: event.pageX, y: event.pageY } },
-                        includeGroundPlane: true,
                         // Ignore frames for raycasting spatial cursor position if in AR mode, due to visual lag
-                        includeFrames: !realityEditor.device.environment.isARMode(),
+                        include: { scene: true, ground: true, frames: !realityEditor.device.environment.isARMode() },
                         flipNormalTowardCamera: false,
-                        relativeToGround: true,
+                        returnSpace: SPACES.GROUND
                     });
                 } else {
                     // Ignore frames for raycasting spatial cursor position if in AR mode, due to visual lag

--- a/content_scripts/desktopAdapter.js
+++ b/content_scripts/desktopAdapter.js
@@ -253,7 +253,8 @@ createNameSpace('realityEditor.device.desktopAdapter');
 
         document.getElementById('groundPlaneResetButton').classList.add('hiddenDesktopButton');
 
-        realityEditor.device.layout.onViewportResized(({width, height}) => {
+        let onResizeListener = realityEditor.device.layout.onViewportResized ?? realityEditor.device.layout.onWindowResized;
+        onResizeListener(({width, height}) => {
             calculateProjectionMatrices(width, height);
         });
 

--- a/content_scripts/desktopAdapter.js
+++ b/content_scripts/desktopAdapter.js
@@ -253,7 +253,7 @@ createNameSpace('realityEditor.device.desktopAdapter');
 
         document.getElementById('groundPlaneResetButton').classList.add('hiddenDesktopButton');
 
-        realityEditor.device.layout.onWindowResized(({width, height}) => {
+        realityEditor.device.layout.onViewportResized(({width, height}) => {
             calculateProjectionMatrices(width, height);
         });
 

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -15,7 +15,13 @@ import { CameraFollowCoordinator } from './CameraFollowCoordinator.js';
 import { MotionStudyFollowable } from './MotionStudyFollowable.js';
 import { TouchControlButtons } from './TouchControlButtons.js';
 import { CameraPositionMemoryBar } from './CameraPositionMemoryBar.js';
-import ui from '../../src/gui/UIManager.js';
+
+let ui; // import ui from '../../src/gui/UIManager.js'; <-- use this when we've fully migrated
+try {
+    ui = await import('../../src/gui/UIManager.js');
+} catch (_err) {
+    console.warn('[VirtualCamera.js] UIManager.js not found, skipping import.');
+}
 
 /**
  * @fileOverview realityEditor.device.desktopCamera.js

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -15,6 +15,7 @@ import { CameraFollowCoordinator } from './CameraFollowCoordinator.js';
 import { MotionStudyFollowable } from './MotionStudyFollowable.js';
 import { TouchControlButtons } from './TouchControlButtons.js';
 import { CameraPositionMemoryBar } from './CameraPositionMemoryBar.js';
+import ui from '../../src/gui/UIManager.js';
 
 /**
  * @fileOverview realityEditor.device.desktopCamera.js
@@ -473,7 +474,7 @@ import { CameraPositionMemoryBar } from './CameraPositionMemoryBar.js';
             border.appendChild(textDiv);
         }
 
-        document.body.appendChild(border);
+        ui.addToZone(ui.VIEWPORT, border);
     }
 
     /**
@@ -508,7 +509,7 @@ import { CameraPositionMemoryBar } from './CameraPositionMemoryBar.js';
 
         // add the buttons to the screen
         touchControlButtons = new TouchControlButtons();
-        document.body.appendChild(touchControlButtons.container);
+        ui.addToZone(ui.VIEWPORT, touchControlButtons.container);
         touchControlButtons.container.id = 'touchControlsContainer';
 
         const FLAG_NAME = 'touchCameraControlButtons';

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -16,11 +16,12 @@ import { MotionStudyFollowable } from './MotionStudyFollowable.js';
 import { TouchControlButtons } from './TouchControlButtons.js';
 import { CameraPositionMemoryBar } from './CameraPositionMemoryBar.js';
 
-let ui; // import ui from '../../src/gui/UIManager.js'; <-- use this when we've fully migrated
+let uiManager; // import ui from '../../src/gui/UIManager.js'; <-- use this when we've fully migrated
 try {
-    ui = await import('../../src/gui/UIManager.js');
+    // import the singleton UIManager to add elements to the viewport
+    uiManager = await import('../../src/gui/UIManager.js');
 } catch (_err) {
-    console.warn('[VirtualCamera.js] UIManager.js not found, skipping import.');
+    console.warn('[desktopCamera.js] UIManager.js not found, skipping import.');
 }
 
 /**
@@ -480,8 +481,8 @@ try {
             border.appendChild(textDiv);
         }
 
-        if (ui) {
-            ui.addToZone(ui.VIEWPORT, border);
+        if (uiManager) {
+            uiManager.addToZone(uiManager.VIEWPORT, border);
         } else {
             document.body.appendChild(border);
         }
@@ -519,8 +520,8 @@ try {
 
         // add the buttons to the screen
         touchControlButtons = new TouchControlButtons();
-        if (ui) {
-            ui.addToZone(ui.VIEWPORT, touchControlButtons.container);
+        if (uiManager) {
+            uiManager.addToZone(uiManager.VIEWPORT, touchControlButtons.container);
         } else {
             document.body.appendChild(touchControlButtons.container);
         }

--- a/content_scripts/desktopCamera.js
+++ b/content_scripts/desktopCamera.js
@@ -480,7 +480,11 @@ try {
             border.appendChild(textDiv);
         }
 
-        ui.addToZone(ui.VIEWPORT, border);
+        if (ui) {
+            ui.addToZone(ui.VIEWPORT, border);
+        } else {
+            document.body.appendChild(border);
+        }
     }
 
     /**
@@ -515,7 +519,11 @@ try {
 
         // add the buttons to the screen
         touchControlButtons = new TouchControlButtons();
-        ui.addToZone(ui.VIEWPORT, touchControlButtons.container);
+        if (ui) {
+            ui.addToZone(ui.VIEWPORT, touchControlButtons.container);
+        } else {
+            document.body.appendChild(touchControlButtons.container);
+        }
         touchControlButtons.container.id = 'touchControlsContainer';
 
         const FLAG_NAME = 'touchCameraControlButtons';


### PR DESCRIPTION
Goes with https://github.com/dataTimeSpace/vuforia-spatial-toolbox-userinterface/pull/147

Backwards-compatible.

Unrelatedly, makes it so when you hit the Escape key, it centers the camera on the centroid of the scan.